### PR TITLE
Added COMPILE pragma to maybe type

### DIFF
--- a/maybe.agda
+++ b/maybe.agda
@@ -9,8 +9,10 @@ open import bool
 ----------------------------------------------------------------------
 
 data maybe {ℓ}(A : Set ℓ) : Set ℓ where
-  just : A → maybe A
   nothing : maybe A
+  just : A → maybe A
+
+{-# COMPILE GHC maybe = data Maybe (Nothing | Just) #-}
 
 ----------------------------------------------------------------------
 -- operations


### PR DESCRIPTION
...and had to put "nothing" constructor before "just" as that is how it is in the Haskell Prelude.
This will allow us to import types defined with Maybe in Haskell into Agda.