### PR TITLE
Add agda-vim temp files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.agdai
+*.vim


### PR DESCRIPTION
Using vim perhaps isn't the recommended way of doing Agda, but it works quite well, and this little change helps a lot.