### PR TITLE
Pass termination checking in Agda-2.6.1

### DIFF
--- a/braun-tree.agda
+++ b/braun-tree.agda
@@ -36,18 +36,18 @@ bt-replace-min a (bt-node _ bt-empty bt-empty u) = (bt-node a bt-empty bt-empty 
 bt-replace-min a (bt-node _ bt-empty (bt-node _ _ _ _) (inj₁ ()))
 bt-replace-min a (bt-node _ bt-empty (bt-node _ _ _ _) (inj₂ ()))
 bt-replace-min a (bt-node _ (bt-node _ _ _ _) bt-empty (inj₁ ()))
-bt-replace-min a (bt-node a' (bt-node x l r u) bt-empty (inj₂ y)) with a <A x
-bt-replace-min a (bt-node a' (bt-node x l r u) bt-empty (inj₂ y)) | tt = (bt-node a (bt-node x l r u) bt-empty (inj₂ y))
-bt-replace-min a (bt-node a' (bt-node x l r u) bt-empty (inj₂ y)) | ff = 
- (bt-node x (bt-replace-min a (bt-node x l r u)) bt-empty (inj₂ y))
-bt-replace-min a (bt-node a' (bt-node x l r u) (bt-node x' l' r' u') v) with a <A x && a <A x' 
-bt-replace-min a (bt-node a' (bt-node x l r u) (bt-node x' l' r' u') v) | tt = 
+bt-replace-min a (bt-node a' (bt-node x l r u) bt-empty (inj₂ y)) with bt-replace-min a (bt-node x l r u) | a <A x
+bt-replace-min a (bt-node a' (bt-node x l r u) bt-empty (inj₂ y)) | _ | tt = (bt-node a (bt-node x l r u) bt-empty (inj₂ y))
+bt-replace-min a (bt-node a' (bt-node x l r u) bt-empty (inj₂ y)) | rec | ff = 
+ (bt-node x rec bt-empty (inj₂ y))
+bt-replace-min a (bt-node a' (bt-node x l r u) (bt-node x' l' r' u') v) with bt-replace-min a (bt-node x l r u) | bt-replace-min a (bt-node x' l' r' u') | a <A x && a <A x' 
+bt-replace-min a (bt-node a' (bt-node x l r u) (bt-node x' l' r' u') v) | _ | _ | tt = 
  (bt-node a (bt-node x l r u) (bt-node x' l' r' u') v)
-bt-replace-min a (bt-node a' (bt-node x l r u) (bt-node x' l' r' u') v) | ff with x <A x'  
-bt-replace-min a (bt-node a' (bt-node x l r u) (bt-node x' l' r' u') v) | ff | tt = 
- (bt-node x (bt-replace-min a (bt-node x l r u)) (bt-node x' l' r' u') v)
-bt-replace-min a (bt-node a' (bt-node x l r u) (bt-node x' l' r' u') v) | ff | ff = 
- (bt-node x' (bt-node x l r u) (bt-replace-min a (bt-node x' l' r' u')) v)
+bt-replace-min a (bt-node a' (bt-node x l r u) (bt-node x' l' r' u') v) | rec₁ | rec₂ | ff with x <A x'  
+bt-replace-min a (bt-node a' (bt-node x l r u) (bt-node x' l' r' u') v) | rec₁ | _ | ff | tt = 
+ (bt-node x rec₁ (bt-node x' l' r' u') v)
+bt-replace-min a (bt-node a' (bt-node x l r u) (bt-node x' l' r' u') v) | _ | rec₂ | ff | ff = 
+ (bt-node x' (bt-node x l r u) rec₂ v)
 
 {- thanks to Matías Giovannini for the excellent post
      http://alaska-kamtchatka.blogspot.com/2010/02/braun-trees.html
@@ -59,15 +59,16 @@ bt-delete-min (bt-node a bt-empty (bt-node _ _ _ _) (inj₂ ()))
 bt-delete-min (bt-node a (bt-node{n'}{m'} a' l' r' u') bt-empty u) rewrite +0 (n' + m') = bt-node a' l' r' u'
 bt-delete-min (bt-node a
                 (bt-node{n}{m} x l1 r1 u1)
-                (bt-node{n'}{m'} x' l2 r2 u2) u) 
+                (bt-node{n'}{m'} x' l2 r2 u2) u) with bt-delete-min (bt-node x l1 r1 u1)
+bt-delete-min (bt-node a
+                (bt-node{n}{m} x l1 r1 u1)
+                (bt-node{n'}{m'} x' l2 r2 u2) u) | rec
   rewrite +suc(n + m)(n' + m') | +suc n (m + (n' + m')) 
         | +comm(n + m)(n' + m') = 
   if (x <A x') then
-    (bt-node x (bt-node x' l2 r2 u2)
-      (bt-delete-min (bt-node x l1 r1 u1)) (lem{n}{m}{n'}{m'} u))
+    (bt-node x (bt-node x' l2 r2 u2) rec (lem{n}{m}{n'}{m'} u))
   else
-    (bt-node x' (bt-replace-min x (bt-node x' l2 r2 u2))
-      (bt-delete-min (bt-node x l1 r1 u1)) (lem{n}{m}{n'}{m'} u))
+    (bt-node x' (bt-replace-min x (bt-node x' l2 r2 u2)) rec (lem{n}{m}{n'}{m'} u))
   where lem : {n m n' m' : ℕ} → suc (n + m) ≡ suc (n' + m') ∨ suc (n + m) ≡ suc (suc (n' + m')) → 
               suc (n' + m') ≡ n + m ∨ suc (n' + m') ≡ suc (n + m)
         lem{n}{m}{n'}{m'} (inj₁ x) = inj₂ (sym x)

--- a/huffman/main.agda
+++ b/huffman/main.agda
@@ -62,11 +62,11 @@ build-huffman-pqueue ((s , f) :: l) = pq-insert (ht-leaf s f) (build-huffman-pqu
 -- where we call this function, we have enough evidence to prove the Braun tree is nonempty 
 process-huffman-pqueue : ∀{n} → n =ℕ 0 ≡ ff → pqueue n → huffman-tree
 process-huffman-pqueue{0} () b
-process-huffman-pqueue{suc n} _ t with pq-remove-min t 
-process-huffman-pqueue{suc 0} _ t | h , _ = h
-process-huffman-pqueue{suc (suc n)} _ _ | h , t with pq-remove-min t 
-process-huffman-pqueue{suc (suc n)} _ _ | h , _ | h' , t =
-  process-huffman-pqueue{suc n} refl (pq-insert (ht-node ((ht-frequency h) + (ht-frequency h')) h h') t)
+process-huffman-pqueue{suc n} _ t with (λ r x → process-huffman-pqueue {n} r x) | pq-remove-min t 
+process-huffman-pqueue{suc 0} _ t | _ | h , _ = h
+process-huffman-pqueue{suc (suc n)} _ _ | _ | h , t with pq-remove-min t 
+process-huffman-pqueue{suc (suc n)} _ _ | rec | h , _ | h' , t =
+  rec refl (pq-insert (ht-node ((ht-frequency h) + (ht-frequency h')) h h') t)
 
 build-mappingh : huffman-tree → trie string → 𝕃 char → trie string
 build-mappingh (ht-leaf s _) m l = trie-insert m s (𝕃char-to-string (reverse l))

--- a/list-merge-sort.agda
+++ b/list-merge-sort.agda
@@ -11,9 +11,9 @@ open import nat-thms
 merge : (l1 l2 : 𝕃 A) → 𝕃 A
 merge [] ys = ys
 merge xs [] = xs
-merge (x :: xs) (y :: ys) with x <A y
-merge (x :: xs) (y :: ys) | tt = x :: (merge xs (y :: ys))
-merge (x :: xs) (y :: ys) | ff = y :: (merge (x :: xs) ys)
+merge (x :: xs) (y :: ys) with merge xs (y :: ys) | merge (x :: xs) ys | x <A y
+merge (x :: xs) (y :: ys) | rec₁ | _ | tt = x :: rec₁
+merge (x :: xs) (y :: ys) | _ | rec₂ | ff = y :: rec₂
 
 merge-sort-h : ∀{n : ℕ} → braun-tree' n → 𝕃 A
 merge-sort-h (bt'-leaf a) = [ a ]


### PR DESCRIPTION
In Agda-2.6.1, termination checking fails for `braun-tree.bt-replace-min`, `braun-tree.bt-delete-min` and `list-merge-sort.merge`, which have some recursive calls with `with`-abstraction.

The link below describes how to pass termination checking with `with`-abstraction.
https://agda.readthedocs.io/en/v2.6.1/language/with-abstraction.html#termination-checking

This PR is related to issue #7 .